### PR TITLE
Remove mentions of nickname from poker code

### DIFF
--- a/src/main/java/me/ars/pokerbot/irc/Irc.java
+++ b/src/main/java/me/ars/pokerbot/irc/Irc.java
@@ -1,5 +1,18 @@
 package me.ars.pokerbot.irc;
 
+import me.ars.pokerbot.poker.Player;
+
+import java.util.List;
+
 public interface Irc {
     void message(String channel, String message);
+
+    /**
+     * Sends a message to a player
+     * @param player
+     * @param message
+     */
+    void message(Player player, String message);
+
+    void gameEnded(List<Player> players);
 }

--- a/src/main/java/me/ars/pokerbot/irc/IrcPlayer.java
+++ b/src/main/java/me/ars/pokerbot/irc/IrcPlayer.java
@@ -1,0 +1,43 @@
+package me.ars.pokerbot.irc;
+
+import me.ars.pokerbot.poker.Player;
+
+public class IrcPlayer extends Player {
+
+    private String nick;
+    private String login;
+    private String host;
+
+    public IrcPlayer(String identifier) {
+        super(identifier);
+    }
+
+    public String getLogin() {
+        return login;
+    }
+
+    public void setLogin(String login) {
+        this.login = login;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    @Override
+    public String getName() {
+        return nick;
+    }
+
+    public String getNick() {
+        return nick;
+    }
+
+    public void setNick(String nick) {
+        this.nick = nick;
+    }
+}

--- a/src/main/java/me/ars/pokerbot/poker/Player.java
+++ b/src/main/java/me/ars/pokerbot/poker/Player.java
@@ -3,72 +3,79 @@ package me.ars.pokerbot.poker;
 import java.util.Objects;
 
 public class Player {
-	private final String name;
-	private int money;
-
-	/*
-	 * how much this player has payed in a given hand
+	/**
+	 * Immutable unique identifier for this player.
 	 */
-	private int payed = 0;
-
+	private final String uniqueIdentifier;
+	private int money;
 	private Card card1, card2;
 	private boolean active = true;
 	private boolean folded = false;
 	private boolean isAllIn = false;
 
+	/**
+	 * Creates a new Player object.
+	 *
+	 * @param uniqueIdentifier An identifier for this player that will not change over the course of the game.
+	 */
+	public Player(String uniqueIdentifier) {
+		this.uniqueIdentifier = uniqueIdentifier;
+	}
+
 	@Override
 	public String toString() {
-		return name;
+		return getName();
 	}
 
-	public Player(String name, int startMoney) {
-		this.name = name;
-		this.money = startMoney;
-	}
-
-	public boolean isAllIn() {
+	public final boolean isAllIn() {
 		return isAllIn;
 	}
 
-	public void setAllIn(boolean allIn) {
+	final void setAllIn(boolean allIn) {
 		isAllIn = allIn;
 	}
 
+	/**
+	 * Returns the name of the player.
+	 * This returns the unique identifier by default. You should override this if it would make more sense in your
+	 * implementation, for instance to instead return an irc nickname (which is something that could change).
+	 *
+	 * @return Name of the player
+	 */
 	public String getName() {
-		return name;
+		return uniqueIdentifier;
 	}
 
-	public int getMoney() {
+	public final int getMoney() {
 		return money;
 	}
 
-	public boolean isBroke() {
+	final void setMoney(int money) {
+		this.money = money;
+	}
+
+	public final boolean isBroke() {
 		return money == 0;
 	}
 
-	public int getAmountPayed() {
-		return payed;
-	}
-
-	public void newHand() {
-		payed = 0;
+	final void newHand() {
 		folded = false;
 	}
 
-	public void receiveCards(Card card1, Card card2) {
+	final void receiveCards(Card card1, Card card2) {
 		this.card1 = card1;
 		this.card2 = card2;
 	}
 
-	public Card getCard1() {
+	public final Card getCard1() {
 		return card1;
 	}
 
-	public Card getCard2() {
+	public final Card getCard2() {
 		return card2;
 	}
 
-	public boolean isFolded() {
+	public final boolean isFolded() {
 		return folded;
 	}
 
@@ -76,28 +83,26 @@ public class Player {
 		return active;
 	}
 
-	public int bet(int amount) {
+	final int bet(int amount) {
 		if (!active)
 			return 0;
-
-		payed += amount;
 		money -= amount;
 		return amount;
 	}
 
-	public void win(int pot) {
+	final void win(int pot) {
 		if (!active)
 			return;
 
 		money += pot;
 	}
 
-	public void cashout() {
+	final void cashout() {
 		fold();
 		active = false;
 	}
 
-	public void fold() {
+	final void fold() {
 		folded = true;
 	}
 
@@ -106,11 +111,11 @@ public class Player {
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;
 		Player player = (Player) o;
-		return name.equals(player.name);
+		return uniqueIdentifier.equals(player.uniqueIdentifier);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(name);
+		return Objects.hash(uniqueIdentifier);
 	}
 }

--- a/src/main/java/me/ars/pokerbot/poker/Pot.java
+++ b/src/main/java/me/ars/pokerbot/poker/Pot.java
@@ -97,21 +97,21 @@ public class Pot {
     }
 
     public void collectAnte(Player player, int ante) {
-        System.out.println("Collecting ante from " + player + ", total paid: " + player.getAmountPayed());
         currentBet = ante;
         addContribution(player, player.bet(ante));
+        System.out.println("Collecting ante from " + player + ", total paid: " + getTotalContribution(player));
     }
 
     public int collectBigBlind(Player player, int bigBlind) {
-        System.out.println("Collecting big blind (" + bigBlind + ") from " + player);
         raise(player, bigBlind - (int) Math.ceil(((double) bigBlind) / 2));
+        System.out.println("Collecting big blind (" + bigBlind + ") from " + player);
         return bigBlind;
     }
 
     public int collectSmallBlind(Player player, int bigBlind) {
         final int smallBlind = (int) Math.ceil(((double) bigBlind) / 2);
-        System.out.println("Collecting small blind (" + smallBlind + ") from " + player);
         raise(player, smallBlind);
+        System.out.println("Collecting small blind (" + smallBlind + ") from " + player);
         return smallBlind;
     }
 
@@ -163,12 +163,12 @@ public class Pot {
             }
         }
         if (sidePot == null) {
-            System.out.println(player + " has raised by " + totalRaised);
             currentBet += amount;
             addContribution(player, player.bet(totalRaised));
+            System.out.println(player + " has raised by " + totalRaised);
         } else {
-            System.out.println(player + " raised, but its going into a sidepot");
             sidePot.raise(player, totalRaised);
+            System.out.println(player + " raised, but its going into a sidepot");
         }
         return totalRaised-owed;
     }

--- a/src/main/java/me/ars/pokerbot/poker/StateCallback.java
+++ b/src/main/java/me/ars/pokerbot/poker/StateCallback.java
@@ -7,25 +7,25 @@ public interface StateCallback {
     /**
      * A player has called a bet. If the player didn't have enough money, then [money] will be lower than [owed].
      *
-     * @param nick  Nickname of caller
-     * @param money Amount called
+     * @param player  Player who called
+     * @param money   Amount called
      */
-    void playerCalled(String nick, int money);
+    void playerCalled(Player player, int money);
 
     /**
      * A player has raised a bet.
      *
-     * @param name     Player who raised
+     * @param player   Player who raised
      * @param newRaise Amount that was raised
      */
-    void playerRaised(String name, int newRaise);
+    void playerRaised(Player player, int newRaise);
 
     /**
      * A player has checked.
      *
-     * @param name Checking player
+     * @param player Checking player
      */
-    void playerChecked(String name);
+    void playerChecked(Player player);
 
     /**
      * Announce a message to all players.
@@ -41,94 +41,94 @@ public interface StateCallback {
      * @param pot           Current pot on the table
      * @param currentPlayer Current players turn
      */
-    void updateTable(List<Card> table, int pot, String currentPlayer);
+    void updateTable(List<Card> table, int pot, Player currentPlayer);
 
     /**
      * Notify that a player must call a raise.
      *
-     * @param name       Player who needs to call
+     * @param player     Player who needs to call
      * @param amountOwed Amount of money needed to call
      */
-    void mustCallRaise(String name, int amountOwed);
+    void mustCallRaise(Player player, int amountOwed);
 
     /**
      * Announce that a player could not raise the specified bet.
      *
-     * @param name   Player who tried to bet
+     * @param player Player who tried to bet
      * @param money  Amount of money they actually had
      */
-    void playerCannotRaise(String name, int money);
+    void playerCannotRaise(Player player, int money);
 
     /**
      * A player has gone all in.
      *
-     * @param name Name of allin player
+     * @param player Player who went all in.
      */
-    void playerAllin(String name);
+    void playerAllin(Player player);
 
     /**
      * A player has folded.
      *
-     * @param name Name of folding player
+     * @param player Folding player
      */
-    void playerFolded(String name);
+    void playerFolded(Player player);
 
     /**
      * A player cashed out and left the table.
      *
-     * @param name  Name of cashing out player
+     * @param player Cashing out player
      * @param money Amount of money they walked away with
      */
-    void playerCashedOut(String name, int money);
+    void playerCashedOut(Player player, int money);
 
     /**
      * Show the player the two cards they were dealt.
      *
-     * @param name  Name of player
+     * @param player Player receiving their cards
      * @param card1 First card
      * @param card2 Second card
      * @param spycard If playing with spycards
      */
-    void showPlayerCards(String name, Card card1, Card card2, Card spycard);
+    void showPlayerCards(Player player, Card card1, Card card2, Card spycard);
 
     /**
      * Display the currently playing players and the money they have
      *
-     * @param players Map of player names to how much money they have
+     * @param players Map of players to how much money they have
      */
-    void showPlayers(Map<String, Integer> players);
+    void showPlayers(Map<Player, Integer> players);
 
     /**
      * Reveals the hands of the supplied players.
      *
-     * @param reveal Names mapped to their own cards
+     * @param reveal Players mapped to their own cards
      */
-    void revealPlayers(Map<String, List<Card>> reveal);
+    void revealPlayers(Map<Player, List<Card>> reveal);
 
     /**
      * Declare that a player has won the pot
      *
-     * @param name        Name of winner
+     * @param winner      Winning player
      * @param winningHand Their winning hand
      * @param pot         Money they've won from the pot
      */
-    void declareWinner(String name, Hand winningHand, int pot);
+    void declareWinner(Player winner, Hand winningHand, int pot);
 
     /**
      * Declare that there are multiple winners splitting the pot
      *
-     * @param winners  Name of all winners
+     * @param winners  List of winning players
      * @param handType The hand type they had in common
      * @param pot      The pot they are splitting
      */
-    void declareSplitPot(List<String> winners, Hand.HandType handType, int pot);
+    void declareSplitPot(List<Player> winners, Hand.HandType handType, int pot);
 
     /**
-     * Declares whos turn it is.
+     * Declares who's turn it is.
      *
      * @param player Current player
      */
-    void declarePlayerTurn(String player);
+    void declarePlayerTurn(Player player);
 
     /**
      * Declare that ante is being collected
@@ -145,5 +145,12 @@ public interface StateCallback {
      * @param smallBlindPlayer The player that pays the small blind
      * @param smallBlind       How big the small blind is
      */
-    void collectBlinds(String bigBlindPlayer, int bigBlind, String smallBlindPlayer, int smallBlind);
+    void collectBlinds(Player bigBlindPlayer, int bigBlind, Player smallBlindPlayer, int smallBlind);
+
+    /**
+     * Declare that the game has ended.
+     *
+     * @param oldPlayers Players that have left the ended game
+     */
+    void gameEnded(List<Player> oldPlayers);
 }

--- a/src/test/java/me/ars/pokerbot/poker/HandTest.java
+++ b/src/test/java/me/ars/pokerbot/poker/HandTest.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 public class HandTest {
 
-  private final Player player = new Player("tester", 200);
+  private final Player player = new Player("tester");
 
   @Test
   public void testHighCard() {
@@ -301,7 +301,7 @@ public class HandTest {
     16:15 < Poker> Reveal: [player1 - 6♣, 2♥] [player2 - 2♣, 2♠]
     16:15 < Poker> player2 wins with the hand 3♦, Q♥, J♦, 8♥, 2♠ (one pair)!
      */
-    final Player player2 = new Player("player2", 200);
+    final Player player2 = new Player("player2");
     final Card card1 = new Card(8, Suit.HEARTS);
     final Card card2 = new Card(12, Suit.DIAMONDS);
     final Card card3 = new Card(3, Suit.DIAMONDS);

--- a/src/test/java/me/ars/pokerbot/poker/PotTest.java
+++ b/src/test/java/me/ars/pokerbot/poker/PotTest.java
@@ -22,9 +22,12 @@ public class PotTest {
 
   @Before
   public void setup() {
-    player1 = new Player("player1", 200);
-    player2 = new Player("player2", 200);
-    player3 = new Player("player3", 200);
+    player1 = new Player("player1");
+    player1.setMoney(200);
+    player2 = new Player("player2");
+    player2.setMoney(200);
+    player3 = new Player("player3");
+    player3.setMoney(200);
   }
 
   @Test
@@ -66,7 +69,6 @@ public class PotTest {
     pot.raise(player1, 50);
     final int paid = 50 + ANTE;
     Assert.assertEquals(paid, pot.getTotalContribution(player1));
-    Assert.assertEquals(paid, player1.getAmountPayed());
     Assert.assertEquals("Player 2 should owe the new raise", 50, pot.getTotalOwed(player2));
     pot.call(player2);
     pot.call(player3);
@@ -141,8 +143,10 @@ public class PotTest {
 
   @Test
   public void testMakingSidePots() {
-    final Player scrooge = new Player("Scrooge", 200);
-    final Player donald = new Player("Donald", 100);
+    final Player scrooge = new Player("Scrooge");
+    scrooge.setMoney(200);
+    final Player donald = new Player("Donald");
+    donald.setMoney(100);
     final Pot pot = new Pot();
     pot.raise(scrooge, 150);
     pot.call(donald);
@@ -160,9 +164,12 @@ public class PotTest {
 
   @Test
   public void testMakingSidePotsThreePlayers() {
-    final Player scrooge = new Player("Scrooge", 500);
-    final Player gearloose = new Player("Gearloose", 200);
-    final Player donald = new Player("Donald", 50);
+    final Player scrooge = new Player("Scrooge");
+    scrooge.setMoney(500);
+    final Player gearloose = new Player("Gearloose");
+    gearloose.setMoney(200);
+    final Player donald = new Player("Donald");
+    donald.setMoney(50);
     final Set<Player> everyone = toSet(scrooge, gearloose, donald);
     final Pot pot = new Pot();
     pot.raise(scrooge, 100);
@@ -180,9 +187,12 @@ public class PotTest {
 
   @Test
   public void testAllins() {
-    final Player scrooge = new Player("Scrooge", 500);
-    final Player gearloose = new Player("Gearloose", 200);
-    final Player donald = new Player("Donald", 50);
+    final Player scrooge = new Player("Scrooge");
+    scrooge.setMoney(500);
+    final Player gearloose = new Player("Gearloose");
+    gearloose.setMoney(200);
+    final Player donald = new Player("Donald");
+    donald.setMoney(50);
     final Set<Player> everyone = toSet(scrooge, gearloose, donald);
     final Pot pot = new Pot();
     pot.raise(scrooge, 100);
@@ -210,9 +220,12 @@ public class PotTest {
 
   @Test
   public void testMultipleSidepots() {
-    final Player scrooge = new Player("Scrooge", 500);
-    final Player gearloose = new Player("Gearloose", 200);
-    final Player donald = new Player("Donald", 50);
+    final Player scrooge = new Player("Scrooge");
+    scrooge.setMoney(500);
+    final Player gearloose = new Player("Gearloose");
+    gearloose.setMoney(200);
+    final Player donald = new Player("Donald");
+    donald.setMoney(50);
     final Set<Player> everyone = toSet(scrooge, gearloose, donald);
     final Set<Player> secondPotParticipants = toSet(scrooge, gearloose);
     final Set<Player> thirdPotParticipants = toSet(scrooge);

--- a/src/test/java/me/ars/pokerbot/poker/TableTest.java
+++ b/src/test/java/me/ars/pokerbot/poker/TableTest.java
@@ -46,11 +46,11 @@ public class TableTest {
     Mockito.doAnswer(invocation -> {
       Object[] args = invocation.getArguments();
       Object mock = invocation.getMock();
-      String winner = (String)args[0];
+      Player winner = (Player)args[0];
       System.out.println(winner + " has won!");
       hadWinner.set(true);
       return null;
-    }).when(callback).declareWinner(anyString(), any(Hand.class), anyInt());
+    }).when(callback).declareWinner(any(Player.class), any(Hand.class), anyInt());
 
     Mockito.doAnswer(invocation -> {
       Object[] args = invocation.getArguments();
@@ -63,16 +63,16 @@ public class TableTest {
     Mockito.doAnswer(invocation -> {
       Object[] args = invocation.getArguments();
       Object mock = invocation.getMock();
-      String currentPlayer = (String)args[2];
+      Player currentPlayer = (Player)args[2];
       List<Card> cards = (List<Card>)args[0];
       final String tableStr = cards.isEmpty() ? "no cards" : cards.stream()
           .map(Card::toString).collect(Collectors.joining(", "));
       System.out.println(currentPlayer + " - " + tableStr);
       return null;
-    }).when(callback).updateTable(anyList(),anyInt(),anyString());
+    }).when(callback).updateTable(anyList(),anyInt(),any(Player.class));
 
-    final String player1 = "player1";
-    final String player2 = "player2";
+    final Player player1 = new Player("player1");
+    final Player player2 = new Player("player2");
     table.registerPlayer(player1);
     table.registerPlayer(player2);
     table.startGame();
@@ -90,44 +90,111 @@ public class TableTest {
   @Test
   public void testTurnOrderWithAnte() {
     table = new Table(callback, roster, anteConfig());
-    final String player1 = "player1";
-    final String player2 = "player2";
+    final Player player1 = new Player("player1");
+    final Player player2 = new Player("player2");
     table.registerPlayer(player1);
     table.registerPlayer(player2);
-    final Player p1 = table.getPlayer(player1);
-    final Player p2 = table.getPlayer(player2);
     table.startGame();
-    Assert.assertEquals("The first joined player should be the first to play", p1, table.getCurrentPlayer());
+    Assert.assertEquals("The first joined player should be the first to play", player1, table.getCurrentPlayer());
     table.check(player1);
-    Assert.assertEquals("Player 2 should be next", p2, table.getCurrentPlayer());
+    Assert.assertEquals("Player 2 should be next", player2, table.getCurrentPlayer());
     table.check(player2);
-    Assert.assertEquals("Player 1 should be next", p1, table.getCurrentPlayer());
+    Assert.assertEquals("Player 1 should be next", player1, table.getCurrentPlayer());
     table.check(player1);
-    Assert.assertEquals("Player 2 should be next", p2, table.getCurrentPlayer());
+    Assert.assertEquals("Player 2 should be next", player2, table.getCurrentPlayer());
     table.raise(player2, 5);
-    Assert.assertEquals("It should be player 1's turn after player 2 has raised", p1, table.getCurrentPlayer());
+    Assert.assertEquals("It should be player 1's turn after player 2 has raised", player1, table.getCurrentPlayer());
     table.call(player1);
-    Assert.assertEquals("It should be back to Player 1's turn", p1, table.getCurrentPlayer());
+    Assert.assertEquals("It should be back to Player 1's turn", player1, table.getCurrentPlayer());
   }
 
   @Test
   public void testTurnOrderWithBlinds() {
-    final String player1 = "player1";
-    final String player2 = "player2";
-    table.registerPlayer(player1);
-    table.registerPlayer(player2);
-    final Player p1 = table.getPlayer(player1);
-    final Player p2 = table.getPlayer(player2);
+    final Player p1 = new Player("player1");
+    final Player p2 = new Player("player2");
+    table.registerPlayer(p1);
+    table.registerPlayer(p2);
     table.startGame();
     Assert.assertEquals("The first joined player should be the first to play", p1, table.getCurrentPlayer());
-    table.check(player1);
+    table.check(p1);
     Assert.assertEquals("Player 1 cannot check without calling the blind, it should still be player 1s turn",
             p1, table.getCurrentPlayer());
-    table.call(player1);
+    table.call(p1);
     Assert.assertEquals("After player 1 calls, it should be player 2", p2, table.getCurrentPlayer());
-    table.check(player2);
+    table.check(p2);
     Assert.assertEquals("Player 2 should be able to check, and it should be back to player 1", p1,
             table.getCurrentPlayer());
+  }
+
+  @Test
+  public void testCashoutDuringGame() {
+    final Player p1 = new Player("player1");
+    final Player p2 = new Player("player2");
+    final Player p3 = new Player("player3");
+    table.registerPlayer(p1);
+    table.registerPlayer(p2);
+    table.registerPlayer(p3);
+    table.startGame();
+    Assert.assertEquals("The first joined player should be the first to play", p1, table.getCurrentPlayer());
+    table.call(p1);
+    Assert.assertEquals("After player 1 calls, it should be player 2", p2, table.getCurrentPlayer());
+    table.playerLeft(p3);
+    Assert.assertEquals("After player 3 leaves, it should still be player 2", p2, table.getCurrentPlayer());
+    table.check(p2);
+    Assert.assertEquals("Player 2 should be able to check, and it should be back to player 1", p1,
+            table.getCurrentPlayer());
+  }
+
+  @Test
+  public void testCashoutDuringGame2() {
+    final Player p1 = new Player("player1");
+    final Player p2 = new Player("player2");
+    final Player p3 = new Player("player3");
+    table.registerPlayer(p1);
+    table.registerPlayer(p2);
+    table.registerPlayer(p3);
+    table.startGame();
+    Assert.assertEquals("The first joined player should be the first to play", p1, table.getCurrentPlayer());
+    table.playerLeft(p1);
+    Assert.assertEquals("After player 1 leaves, it should be player 2", p2, table.getCurrentPlayer());
+    table.check(p2);
+    Assert.assertEquals("After player 2 checks, it should be player 3", p3, table.getCurrentPlayer());
+    table.call(p3);
+    Assert.assertEquals("Player 3 should be able to call the blind, and it should be back to player 2", p2,
+            table.getCurrentPlayer());
+    table.check(p2);
+    table.check(p3);
+    table.check(p2);
+    table.check(p3);
+    Assert.assertEquals("After player 3 checks, it should be player 2", p2, table.getCurrentPlayer());
+  }
+
+  @Test
+  public void testOtherPlayersCashingOut() {
+    final Helper hadWinner = new Helper(false);
+    final Player p1 = new Player("player1");
+    final Player p2 = new Player("player2");
+    final Player p3 = new Player("player3");
+
+    Mockito.doAnswer(invocation -> {
+      Object[] args = invocation.getArguments();
+      Object mock = invocation.getMock();
+      Player winner = (Player)args[0];
+      Assert.assertEquals("player1 should be the winner", p1, winner);
+      hadWinner.set(true);
+      return null;
+    }).when(callback).declareWinner(any(Player.class), isNull(), anyInt());
+
+    table.registerPlayer(p1);
+    table.registerPlayer(p2);
+    table.registerPlayer(p3);
+    table.startGame();
+    Assert.assertEquals("The first joined player should be the first to play", p1, table.getCurrentPlayer());
+    table.playerLeft(p2);
+    Assert.assertEquals("After player 2 leaves, it should still be player 1", p1, table.getCurrentPlayer());
+    table.playerLeft(p3);
+    Assert.assertTrue("The game must have had a winner", hadWinner.get());
+    Assert.assertFalse("The game should be over", table.isGameInProgress());
   }
 
   /**


### PR DESCRIPTION
Code in the poker package will only refer to the Player class when referring to players and not interchangeably refer to a nickname. This should be the final separation from irc logic in the poker code.